### PR TITLE
add heart beat monitor to AppSyncRTC

### DIFF
--- a/Sources/AWSAppSyncApolloInterceptors/Utilities/AppSyncRealTimeRequest.swift
+++ b/Sources/AWSAppSyncApolloInterceptors/Utilities/AppSyncRealTimeRequest.swift
@@ -5,9 +5,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+import ApolloAPI
 import Foundation
 
-struct AppSyncRealTimeStartRequest: Encodable {
+struct AppSyncRealTimeStartRequest {
+    private static let jsonDecoder = JSONDecoder()
+
     let id: String
     let data: String
     let auth: [String: String]?
@@ -26,6 +29,9 @@ struct AppSyncRealTimeStartRequest: Encodable {
     enum ExtensionsCodingKeys: CodingKey {
         case authorization
     }
+}
+
+extension AppSyncRealTimeStartRequest: Codable {
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -39,5 +45,65 @@ struct AppSyncRealTimeStartRequest: Encodable {
         let extensionEncoder = payloadContainer.superEncoder(forKey: .extensions)
         var extensionContainer = extensionEncoder.container(keyedBy: ExtensionsCodingKeys.self)
         try extensionContainer.encodeIfPresent(auth, forKey: .authorization)
+    }
+
+    init(from decoder: any Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        guard try values.decode(String.self, forKey: .type) == "start" else {
+            throw DecodingError.dataCorrupted(.init(
+                codingPath: [CodingKeys.type],
+                debugDescription: "Unsupported AppSync request type"
+            ))
+        }
+
+        id = try values.decode(String.self, forKey: .id)
+        let payloadDecoder = try values.superDecoder(forKey: .payload)
+        let payloadValues = try payloadDecoder.container(keyedBy: PayloadCodingKeys.self)
+        data = try payloadValues.decode(String.self, forKey: .data)
+
+        let extensionDecoder = try payloadValues.superDecoder(forKey: .extensions)
+        let extensionValues = try? extensionDecoder.container(keyedBy: ExtensionsCodingKeys.self)
+        auth = try extensionValues?.decodeIfPresent([String: String].self, forKey: .authorization)
+    }
+}
+
+extension AppSyncRealTimeStartRequest {
+    init?(from query: String) {
+        guard let data = query.data(using: .utf8),
+              var json = try? JSONSerialization.jsonObject(with: data) as? JSONObject,
+              let type = json["type"] as? String
+        else {
+            return nil
+        }
+
+        if type == "start" { // inject "data" back to payload
+            var dataDict = [String: Any]()
+            var payload = json["payload"] as? JSONObject
+            if let query = payload?["query"] {
+                dataDict["query"] = query
+            }
+
+            if let variables = payload?["variables"] {
+                dataDict["variables"] = variables
+            }
+
+            if !dataDict.isEmpty,
+               let jsonData = try? JSONSerialization.data(withJSONObject: dataDict)
+            {
+                payload?["data"] = String(decoding: jsonData, as: UTF8.self)
+            }
+
+            if let payload {
+                json["payload"] = payload
+            }
+        }
+
+        if let jsonData = try? JSONSerialization.data(withJSONObject: json),
+           let request = try? Self.jsonDecoder.decode(AppSyncRealTimeStartRequest.self, from: jsonData)
+        {
+            self = request
+        } else {
+            return nil
+        }
     }
 }

--- a/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
       "location" : "https://github.com/aws-amplify/amplify-swift.git",
       "state" : {
         "branch" : "lawmicha.apollo",
-        "revision" : "86c7e5f4033ff5e0686839fe6f63f32ced5e059e"
+        "revision" : "22ae18b521a1d67deced0d06dcacce0bfabd2165"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-ui-swift-authenticator",
       "state" : {
-        "revision" : "6561a42866883bd446f33ddb447215d0357d0e43",
-        "version" : "1.1.5"
+        "revision" : "0fcd480946096e1d54b11fcd470e3fe63d2c0f67",
+        "version" : "1.1.6"
       }
     },
     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- refactor `AppSyncRealTimeStartRequest`
- add heart beat monitor while connect to AppSync realtime server
  - force disconnect websocket client when heart beat timed out

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
