### PR TITLE
feat: add user-agent header to graphql requests

### DIFF
--- a/Sources/AWSAppSyncApolloInterceptors/Interceptors/AppSyncInterceptor.swift
+++ b/Sources/AWSAppSyncApolloInterceptors/Interceptors/AppSyncInterceptor.swift
@@ -10,12 +10,13 @@ import ApolloAPI
 import Foundation
 
 public class AppSyncInterceptor: ApolloInterceptor {
+
     public var id: String = UUID().uuidString
 
     let authorizer: AppSyncAuthorizer
+
     public init(_ authorizer: AppSyncAuthorizer) {
         self.authorizer = authorizer
-
     }
 
     public func interceptAsync<Operation>(chain: Apollo.RequestChain,
@@ -25,6 +26,9 @@ public class AppSyncInterceptor: ApolloInterceptor {
     {
         Task {
             do {
+
+                request.addHeader(name: "User-Agent", value: await PackageInfo.userAgent)
+
                 try await retrieveHeadersAndAddToRequest(request)
                 chain.proceedAsync(
                     request: request,

--- a/Sources/AWSAppSyncApolloInterceptors/Utilities/PackageInfo.swift
+++ b/Sources/AWSAppSyncApolloInterceptors/Utilities/PackageInfo.swift
@@ -1,0 +1,64 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import Foundation
+#if canImport(WatchKit)
+import WatchKit
+#elseif canImport(UIKit)
+import UIKit
+#elseif canImport(IOKit)
+import IOKit
+#endif
+#if canImport(AppKit)
+import AppKit
+#endif
+
+class PackageInfo {
+
+    private static let version = "0.0.1"
+
+    @MainActor
+    private static var os: (name: String, version: String) = {
+#if canImport(WatchKit)
+        let device = WKInterfaceDevice.current()
+        return (name: device.systemName, version: device.systemVersion)
+#elseif canImport(UIKit)
+        let device = UIDevice.current
+        return (name: device.systemName, version: device.systemVersion)
+#else
+        return (name: "macOS",
+                version: ProcessInfo.processInfo.operatingSystemVersionString)
+#endif
+    }()
+
+    private static var swiftVersion: String = {
+#if swift(>=7.0)
+        return "unknown"
+#elseif swift(>=6.0)
+        return "6.x"
+#elseif swift(>=5.10)
+        return "5.10"
+#elseif swift(>=5.9)
+        return "5.9"
+#else
+        return "unknown"
+#endif
+    }()
+
+    static var userAgent: String {
+        get async {
+            let (name, version) = await Self.os
+            let compilerInfo = "lang/swift/\(swiftVersion)"
+            let osInfo = "os/\(name)/\(version)"
+            let libInfo = "lib/aws-appsync-apollo-extensions-swift/\(Self.version)"
+
+            return "UA/2.0 \(compilerInfo) \(osInfo) \(libInfo)"
+        }
+    }
+
+}

--- a/Tests/AWSAppSyncApolloInterceptorsTests/Utilities/PackageInfoTests.swift
+++ b/Tests/AWSAppSyncApolloInterceptorsTests/Utilities/PackageInfoTests.swift
@@ -1,0 +1,28 @@
+//
+// Copyright Amazon.com Inc. or its affiliates.
+// All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+
+import XCTest
+@testable import AWSAppSyncApolloInterceptors
+
+class PackageInfoTests: XCTestCase {
+
+    @available(iOS 16.0, *)
+    /// user agent header has format of:
+    /// UA/2.0 lang/swift/x.x(.x) os/[iOS, macOS, watchOS]/x.x(.x) lib/aws-appsync-apollo-extensions-swift/x.x.x
+    func testUserAgentHasCorrectFormat() async throws {
+        let format = try Regex(
+            "^UA/2\\.0 " +
+            "lang/swift/\\d+\\.\\d+(?:\\.\\d+)? " +
+            "os/iOS|macOS|watchOS/\\d+\\.\\d+(?:\\.\\d+)? " +
+            "lib/aws-appsync-apollo-extensions-swift/\\d+\\.\\d+\\.\\d+$"
+        )
+        let userAgent = await PackageInfo.userAgent
+        let matches = userAgent.ranges(of: format)
+        XCTAssertTrue(!matches.isEmpty)
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add `user-agent` header to graphql requests

Example of the user-agent value:
```
UA/2.0 os/iOS/17.5 lib/aws-appsync-apollo-extensions-swift/0.0.1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
