### PR TITLE
fix: adding more info to user-agent header

### DIFF
--- a/Sources/AWSAppSyncApolloExtensions/Utilities/PackageInfo.swift
+++ b/Sources/AWSAppSyncApolloExtensions/Utilities/PackageInfo.swift
@@ -7,6 +7,7 @@
 
 
 import Foundation
+import Apollo
 #if canImport(WatchKit)
 import WatchKit
 #elseif canImport(UIKit)
@@ -31,8 +32,9 @@ class PackageInfo {
         let device = UIDevice.current
         return (name: device.systemName, version: device.systemVersion)
 #else
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
         return (name: "macOS",
-                version: ProcessInfo.processInfo.operatingSystemVersionString)
+                version: "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)")
 #endif
     }()
 
@@ -53,11 +55,12 @@ class PackageInfo {
     static var userAgent: String {
         get async {
             let (name, version) = await Self.os
-            let compilerInfo = "lang/swift/\(swiftVersion)"
-            let osInfo = "os/\(name)/\(version)"
-            let libInfo = "lib/aws-appsync-apollo-extensions-swift/\(Self.version)"
+            let compilerInfo = "lang/swift#\(swiftVersion)"
+            let osInfo = "os/\(name)#\(version)"
+            let libInfo = "lib/aws-appsync-apollo-extensions-swift#\(Self.version)"
+            let dependenciesInfo = "md/apollo#\(Constants.ApolloVersion)"
 
-            return "UA/2.0 \(compilerInfo) \(osInfo) \(libInfo)"
+            return "UA/2.0 \(compilerInfo) \(osInfo) \(libInfo) \(dependenciesInfo)"
         }
     }
 

--- a/Tests/AWSAppSyncApolloExtensionsTests/Utilities/PackageInfoTests.swift
+++ b/Tests/AWSAppSyncApolloExtensionsTests/Utilities/PackageInfoTests.swift
@@ -17,9 +17,10 @@ class PackageInfoTests: XCTestCase {
     func testUserAgentHasCorrectFormat() async throws {
         let format = try Regex(
             "^UA/2\\.0 " +
-            "lang/swift/\\d+\\.\\d+(?:\\.\\d+)? " +
-            "os/iOS|macOS|watchOS/\\d+\\.\\d+(?:\\.\\d+)? " +
-            "lib/aws-appsync-apollo-extensions-swift/\\d+\\.\\d+\\.\\d+$"
+            "lang/swift#\\d+\\.\\d+(?:\\.\\d+)? " +
+            "os/(?:iOS|macOS|watchOS)#\\d+\\.\\d+(?:\\.\\d+)? " +
+            "lib/aws-appsync-apollo-extensions-swift#\\d+\\.\\d+\\.\\d+ " +
+            "md/apollo#\\d+\\.\\d+\\.\\d+$"
         )
         let userAgent = await PackageInfo.userAgent
         let matches = userAgent.ranges(of: format)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Added the apollo-ios version to the User-Agent dependency.
- Fixed the macOS version format. 
  - Previously, it generated strings like `Version 14.6.1 (23G93)`; now it's consistent with semantic versioning as `14.6.1`.
- Updated the delimiter before the version to `#`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
