### PR TITLE
fix: update user agent apollo metadata format

### DIFF
--- a/Sources/AWSAppSyncApolloExtensions/Utilities/PackageInfo.swift
+++ b/Sources/AWSAppSyncApolloExtensions/Utilities/PackageInfo.swift
@@ -58,7 +58,7 @@ class PackageInfo {
             let compilerInfo = "lang/swift#\(swiftVersion)"
             let osInfo = "os/\(name)#\(version)"
             let libInfo = "lib/aws-appsync-apollo-extensions-swift#\(Self.version)"
-            let dependenciesInfo = "md/apollo#\(Constants.ApolloVersion)"
+            let dependenciesInfo = "md/apollo-ios#\(Constants.ApolloVersion)"
 
             return "UA/2.0 \(compilerInfo) \(osInfo) \(libInfo) \(dependenciesInfo)"
         }

--- a/Tests/AWSAppSyncApolloExtensionsTests/Utilities/PackageInfoTests.swift
+++ b/Tests/AWSAppSyncApolloExtensionsTests/Utilities/PackageInfoTests.swift
@@ -12,13 +12,13 @@ import XCTest
 class PackageInfoTests: XCTestCase {
 
     /// user agent header has format of:
-    /// UA/2.0 lang/swift/x.x(.x) os/[iOS, macOS, watchOS]/x.x(.x) lib/aws-appsync-apollo-extensions-swift/x.x.x
+    /// UA/2.0 lang/swift#x.x(.x) os/[iOS, macOS, watchOS]#x.x(.x) lib/aws-appsync-apollo-extensions-swift#x.x.x md/apollo-ios#x.x.x
     func testUserAgentHasCorrectFormat() async throws {
         let pattern = "^UA/2\\.0 " +
             "lang/swift#\\d+\\.\\d+(?:\\.\\d+)? " +
             "os/(?:iOS|macOS|watchOS|tvOS)#\\d+\\.\\d+(?:\\.\\d+)? " +
             "lib/aws-appsync-apollo-extensions-swift#\\d+\\.\\d+\\.\\d+ " +
-            "md/apollo#\\d+\\.\\d+\\.\\d+$"
+            "md/apollo-ios#\\d+\\.\\d+\\.\\d+$"
         let regex = try NSRegularExpression(pattern: pattern)
         let userAgent = await PackageInfo.userAgent
         let matches = regex.numberOfMatches(in: userAgent, options: [], range: NSRange(location: 0, length: userAgent.utf8.count))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- add suffix `-ios` to user agent apollo metadata

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
