### PR TITLE
fix: make URLRequest property thread safe

### DIFF
--- a/Sources/AWSAppSyncApolloExtensions/Websocket/AppSyncWebSocketClient.swift
+++ b/Sources/AWSAppSyncApolloExtensions/Websocket/AppSyncWebSocketClient.swift
@@ -17,9 +17,23 @@ public class AppSyncWebSocketClient: NSObject, ApolloWebSocket.WebSocketClient, 
 
     // MARK: - ApolloWebSocket.WebSocketClient
 
-    public var request: URLRequest
     public var delegate: ApolloWebSocket.WebSocketClientDelegate?
     public var callbackQueue: DispatchQueue
+
+    private let requestLock = NSLock()
+    private var _request: URLRequest
+    public var request: URLRequest {
+        get {
+            requestLock.lock()
+            defer { requestLock.unlock() }
+            return _request
+        }
+        set {
+            requestLock.lock()
+            defer { requestLock.unlock() }
+            _request = newValue
+        }
+    }
 
     // MARK: - Public
 
@@ -71,7 +85,7 @@ public class AppSyncWebSocketClient: NSObject, ApolloWebSocket.WebSocketClient, 
         callbackQueue: DispatchQueue,
         authorizer: AppSyncAuthorizer
     ) {
-        self.request = URLRequest(url: appSyncRealTimeEndpoint(endpointURL))
+        self._request = URLRequest(url: appSyncRealTimeEndpoint(endpointURL))
         self.delegate = delegate
         self.callbackQueue = callbackQueue
         self.authorizer = authorizer

--- a/Tests/AWSAppSyncApolloExtensionsTests/Websocket/AppSyncWebSocketClientTests.swift
+++ b/Tests/AWSAppSyncApolloExtensionsTests/Websocket/AppSyncWebSocketClientTests.swift
@@ -119,6 +119,37 @@ final class AppSyncWebSocketClientTests: XCTestCase {
         await fulfillment(of: [messageReceivedExpectation], timeout: 5)
     }
 
+    func testConcurrentURLRequestAccess() async {
+        let endpoint = URL(string: "https://abc.appsync-api.us-east-1.amazonaws.com/graphql")!
+        
+        let websocket = AppSyncWebSocketClient(
+            endpointURL: endpoint,
+            authorizer: APIKeyAuthorizer(apiKey: "apiKey"))
+        
+        let raceConditionExpectation = expectation(description: "Race condition test")
+        raceConditionExpectation.expectedFulfillmentCount = 2
+        
+        let iterations = 1000
+        
+        // Thread 1: Continuous reading
+        DispatchQueue.global(qos: .userInitiated).async {
+            for _ in 0..<iterations {
+                _ = websocket.request.value(forHTTPHeaderField: "test-header")
+            }
+            raceConditionExpectation.fulfill()
+        }
+        
+        // Thread 2: Continuous writing
+        DispatchQueue.global(qos: .userInitiated).async {
+            for i in 0..<iterations {
+                websocket.request.setValue("value-\(i)", forHTTPHeaderField: "test-header")
+            }
+            raceConditionExpectation.fulfill()
+        }
+        
+        await fulfillment(of: [raceConditionExpectation], timeout: 5)
+    }
+
     private func verifyConnected(
            _ webSocketClient: AppSyncWebSocketClient,
            autoConnectOnNetworkStatusChange: Bool = false,


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-amplify/aws-appsync-apollo-extensions-swift/issues/37

Description of changes:
- Wrapped the AppSyncWebSocketClient request in a lock, providing thread safe access. This prevents a potential crash from concurrent read/writes.

Testing:
- Verified solution is working via a unit test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.