### PR TITLE
fix: memory leak in AppSyncWebSocketClient

### DIFF
--- a/Sources/AWSAppSyncApolloExtensions/Websocket/AppSyncWebSocketClient.swift
+++ b/Sources/AWSAppSyncApolloExtensions/Websocket/AppSyncWebSocketClient.swift
@@ -17,7 +17,7 @@ public class AppSyncWebSocketClient: NSObject, ApolloWebSocket.WebSocketClient, 
 
     // MARK: - ApolloWebSocket.WebSocketClient
 
-    public var delegate: ApolloWebSocket.WebSocketClientDelegate?
+    public weak var delegate: ApolloWebSocket.WebSocketClientDelegate?
     public var callbackQueue: DispatchQueue
 
     private let requestLock = NSLock()


### PR DESCRIPTION
*Issue #, if available:*
#40 

*Description of changes:*
WebSocketTransport holds a strong reference to AppSyncWebSocketClient, and vice versa. This causes a retain cycle that can be solved by making AppSyncWebSocketClient's delegate reference weak.

*Testing:*
Verified solution via memory graph debugger.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
