### PR TITLE
chore: update amplify dependency to fix dependabot alert

### DIFF
--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -21,7 +21,7 @@ jobs:
   build-on-minimum-supported-platforms:
     name: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         include:
           - scheme: AWSAppSyncApolloExtensions

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -28,25 +28,25 @@ jobs:
             os: iOS # Swift 5.9 (Xcode 15.0), iOS v13
             sdk: iphonesimulator17.0
             destination: platform=iOS Simulator,name=iPhone 14,OS=17.0
-            runner: macos-13
+            runner: macos-15
             app: Xcode_15.0.1
           - scheme: AWSAppSyncApolloExtensions
             os: macOS # Swift 5.9 (Xcode 15.0), macOS v10_15
             sdk: macosx14.0
             destination: platform=OS X,arch=x86_64
-            runner: macos-13
+            runner: macos-15
             app: Xcode_15.0.1
           - scheme: AWSAppSyncApolloExtensions
             os: watchOS # Swift 5.9 (Xcode 15.0), watchOS v9
             sdk: watchsimulator10.0
             destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=10.0
-            runner: macos-13
+            runner: macos-15
             app: Xcode_15.0.1
           - scheme: AWSAppSyncApolloExtensions
             os: tvOS # Swift 5.9 (Xcode 15.0), tvOS v13
             sdk: appletvsimulator17.0
             destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=17.0
-            runner: macos-13
+            runner: macos-15
             app: Xcode_15.0.1
 
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -26,28 +26,28 @@ jobs:
         include:
           - scheme: AWSAppSyncApolloExtensions
             os: iOS # Swift 5.9 (Xcode 15.0), iOS v13
-            sdk: iphonesimulator18.0
-            destination: platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.0
+            sdk: iphonesimulator
+            destination: platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.5
             runner: macos-15
-            app: Xcode_16.0.0
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: macOS # Swift 5.9 (Xcode 15.0), macOS v10_15
-            sdk: macosx15.0
-            destination: platform=OS X,arch=x86_64
+            sdk: macosx
+            destination: platform=macOS,arch=arm64
             runner: macos-15
-            app: Xcode_16.0.0
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: watchOS # Swift 5.9 (Xcode 15.0), watchOS v9
             sdk: watchsimulator
-            destination: platform=watchOS Simulator,name=Apple Watch SE (44mm) (2nd generation),OS=11.0
+            destination: platform=watchOS Simulator,name=Apple Watch Series 10 (46mm),OS=11.5
             runner: macos-15
-            app: Xcode_16.0.0
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: tvOS # Swift 5.9 (Xcode 15.0), tvOS v13
             sdk: appletvsimulator
-            destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.0
+            destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.5
             runner: macos-15
-            app: Xcode_16.0.0
+            app: Xcode_16.4.0
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -29,25 +29,25 @@ jobs:
             sdk: iphonesimulator17.0
             destination: platform=iOS Simulator,name=iPhone 14,OS=17.0
             runner: macos-15
-            app: Xcode_15.0.1
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: macOS # Swift 5.9 (Xcode 15.0), macOS v10_15
             sdk: macosx14.0
             destination: platform=OS X,arch=x86_64
             runner: macos-15
-            app: Xcode_15.0.1
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: watchOS # Swift 5.9 (Xcode 15.0), watchOS v9
             sdk: watchsimulator10.0
             destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=10.0
             runner: macos-15
-            app: Xcode_15.0.1
+            app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: tvOS # Swift 5.9 (Xcode 15.0), tvOS v13
             sdk: appletvsimulator17.0
             destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=17.0
             runner: macos-15
-            app: Xcode_15.0.1
+            app: Xcode_16.4.0
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -32,7 +32,7 @@ jobs:
             app: Xcode_16.4.0
           - scheme: AWSAppSyncApolloExtensions
             os: macOS # Swift 5.9 (Xcode 15.0), macOS v10_15
-            sdk: macosx14.0
+            sdk: macosx15.0
             destination: platform=OS X,arch=x86_64
             runner: macos-15
             app: Xcode_16.4.0

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -26,28 +26,28 @@ jobs:
         include:
           - scheme: AWSAppSyncApolloExtensions
             os: iOS # Swift 5.9 (Xcode 15.0), iOS v13
-            sdk: iphonesimulator17.0
-            destination: platform=iOS Simulator,name=iPhone 14,OS=17.0
+            sdk: iphonesimulator18.0
+            destination: platform=iOS Simulator,name=iPhone 16,OS=18.0
             runner: macos-15
-            app: Xcode_16.4.0
+            app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
             os: macOS # Swift 5.9 (Xcode 15.0), macOS v10_15
             sdk: macosx15.0
             destination: platform=OS X,arch=x86_64
             runner: macos-15
-            app: Xcode_16.4.0
+            app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
             os: watchOS # Swift 5.9 (Xcode 15.0), watchOS v9
-            sdk: watchsimulator10.0
-            destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=10.0
+            sdk: watchsimulator11.0
+            destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=11.0
             runner: macos-15
-            app: Xcode_16.4.0
+            app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
             os: tvOS # Swift 5.9 (Xcode 15.0), tvOS v13
-            sdk: appletvsimulator17.0
-            destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=17.0
+            sdk: appletvsimulator18.0
+            destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.0
             runner: macos-15
-            app: Xcode_16.4.0
+            app: Xcode_16.0.0
 
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/build-on-minimum-supported-platform.yaml
+++ b/.github/workflows/build-on-minimum-supported-platform.yaml
@@ -27,7 +27,7 @@ jobs:
           - scheme: AWSAppSyncApolloExtensions
             os: iOS # Swift 5.9 (Xcode 15.0), iOS v13
             sdk: iphonesimulator18.0
-            destination: platform=iOS Simulator,name=iPhone 16,OS=18.0
+            destination: platform=iOS Simulator,name=iPhone 16 Pro Max,OS=18.0
             runner: macos-15
             app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
@@ -38,13 +38,13 @@ jobs:
             app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
             os: watchOS # Swift 5.9 (Xcode 15.0), watchOS v9
-            sdk: watchsimulator11.0
-            destination: platform=watchOS Simulator,name=Apple Watch Series 8 (45mm),OS=11.0
+            sdk: watchsimulator
+            destination: platform=watchOS Simulator,name=Apple Watch SE (44mm) (2nd generation),OS=11.0
             runner: macos-15
             app: Xcode_16.0.0
           - scheme: AWSAppSyncApolloExtensions
             os: tvOS # Swift 5.9 (Xcode 15.0), tvOS v13
-            sdk: appletvsimulator18.0
+            sdk: appletvsimulator
             destination: platform=tvOS Simulator,name=Apple TV 4K (3rd generation),OS=18.0
             runner: macos-15
             app: Xcode_16.0.0

--- a/Tests/IntegrationTestApp/.gitignore
+++ b/Tests/IntegrationTestApp/.gitignore
@@ -1,0 +1,5 @@
+# amplify
+node_modules
+.amplify
+amplify_outputs*
+amplifyconfiguration*

--- a/Tests/IntegrationTestApp/.gitignore
+++ b/Tests/IntegrationTestApp/.gitignore
@@ -1,5 +1,11 @@
+.DS_Store
+/.build
+build/
+
 # amplify
 node_modules
 .amplify
 amplify_outputs*
 amplifyconfiguration*
+
+AppSyncAPI/.build

--- a/Tests/IntegrationTestApp/AppSyncAPI/Package.resolved
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "revision" : "1abd62f6cbc8c1f4405919d7eb6cd8e96967b07c",
+        "version" : "1.25.3"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Mutations/CreateTodoMutation.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Mutations/CreateTodoMutation.graphql.swift
@@ -26,6 +26,9 @@ public class CreateTodoMutation: GraphQLMutation {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("createTodo", CreateTodo?.self, arguments: ["input": .variable("createTodoInput")]),
     ] }
+    public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      CreateTodoMutation.Data.self
+    ] }
 
     public var createTodo: CreateTodo? { __data["createTodo"] }
 
@@ -44,6 +47,9 @@ public class CreateTodoMutation: GraphQLMutation {
         .field("createdAt", AppSyncAPI.AWSDateTime.self),
         .field("content", String?.self),
         .field("owner", String?.self),
+      ] }
+      public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        CreateTodoMutation.Data.CreateTodo.self
       ] }
 
       public var id: AppSyncAPI.ID { __data["id"] }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Mutations/UpdateTodoMutation.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Mutations/UpdateTodoMutation.graphql.swift
@@ -26,6 +26,9 @@ public class UpdateTodoMutation: GraphQLMutation {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("updateTodo", UpdateTodo?.self, arguments: ["input": .variable("updateTodoInput")]),
     ] }
+    public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      UpdateTodoMutation.Data.self
+    ] }
 
     public var updateTodo: UpdateTodo? { __data["updateTodo"] }
 
@@ -44,6 +47,9 @@ public class UpdateTodoMutation: GraphQLMutation {
         .field("createdAt", AppSyncAPI.AWSDateTime.self),
         .field("content", String?.self),
         .field("owner", String?.self),
+      ] }
+      public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        UpdateTodoMutation.Data.UpdateTodo.self
       ] }
 
       public var id: AppSyncAPI.ID { __data["id"] }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Queries/MyQuery.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Queries/MyQuery.graphql.swift
@@ -20,6 +20,9 @@ public class MyQuery: GraphQLQuery {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("listTodos", ListTodos?.self),
     ] }
+    public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      MyQuery.Data.self
+    ] }
 
     public var listTodos: ListTodos? { __data["listTodos"] }
 
@@ -35,6 +38,9 @@ public class MyQuery: GraphQLQuery {
         .field("__typename", String.self),
         .field("items", [Item?].self),
         .field("nextToken", String?.self),
+      ] }
+      public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        MyQuery.Data.ListTodos.self
       ] }
 
       public var items: [Item?] { __data["items"] }
@@ -55,6 +61,9 @@ public class MyQuery: GraphQLQuery {
           .field("createdAt", AppSyncAPI.AWSDateTime.self),
           .field("content", String?.self),
           .field("owner", String?.self),
+        ] }
+        public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+          MyQuery.Data.ListTodos.Item.self
         ] }
 
         public var id: AppSyncAPI.ID { __data["id"] }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Subscriptions/OnCreateSubscription.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Operations/Subscriptions/OnCreateSubscription.graphql.swift
@@ -20,6 +20,9 @@ public class OnCreateSubscription: GraphQLSubscription {
     public static var __selections: [ApolloAPI.Selection] { [
       .field("onCreateTodo", OnCreateTodo?.self),
     ] }
+    public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+      OnCreateSubscription.Data.self
+    ] }
 
     public var onCreateTodo: OnCreateTodo? { __data["onCreateTodo"] }
 
@@ -38,6 +41,9 @@ public class OnCreateSubscription: GraphQLSubscription {
         .field("createdAt", AppSyncAPI.AWSDateTime.self),
         .field("content", String?.self),
         .field("owner", String?.self),
+      ] }
+      public static var __fulfilledFragments: [any ApolloAPI.SelectionSet.Type] { [
+        OnCreateSubscription.Data.OnCreateTodo.self
       ] }
 
       public var id: AppSyncAPI.ID { __data["id"] }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/ModelTodoConnection.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/ModelTodoConnection.graphql.swift
@@ -6,6 +6,7 @@ import ApolloAPI
 public extension Objects {
   static let ModelTodoConnection = ApolloAPI.Object(
     typename: "ModelTodoConnection",
-    implementedInterfaces: []
+    implementedInterfaces: [],
+    keyFields: nil
   )
 }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Mutation.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Mutation.graphql.swift
@@ -6,6 +6,7 @@ import ApolloAPI
 public extension Objects {
   static let Mutation = ApolloAPI.Object(
     typename: "Mutation",
-    implementedInterfaces: []
+    implementedInterfaces: [],
+    keyFields: nil
   )
 }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Query.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Query.graphql.swift
@@ -6,6 +6,7 @@ import ApolloAPI
 public extension Objects {
   static let Query = ApolloAPI.Object(
     typename: "Query",
-    implementedInterfaces: []
+    implementedInterfaces: [],
+    keyFields: nil
   )
 }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Subscription.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Subscription.graphql.swift
@@ -6,6 +6,7 @@ import ApolloAPI
 public extension Objects {
   static let Subscription = ApolloAPI.Object(
     typename: "Subscription",
-    implementedInterfaces: []
+    implementedInterfaces: [],
+    keyFields: nil
   )
 }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Todo.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/Objects/Todo.graphql.swift
@@ -6,6 +6,7 @@ import ApolloAPI
 public extension Objects {
   static let Todo = ApolloAPI.Object(
     typename: "Todo",
-    implementedInterfaces: []
+    implementedInterfaces: [],
+    keyFields: nil
   )
 }

--- a/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/SchemaMetadata.graphql.swift
+++ b/Tests/IntegrationTestApp/AppSyncAPI/Sources/Schema/SchemaMetadata.graphql.swift
@@ -20,11 +20,11 @@ public enum SchemaMetadata: ApolloAPI.SchemaMetadata {
 
   public static func objectType(forTypename typename: String) -> ApolloAPI.Object? {
     switch typename {
-    case "Mutation": return AppSyncAPI.Objects.Mutation
-    case "Todo": return AppSyncAPI.Objects.Todo
-    case "Subscription": return AppSyncAPI.Objects.Subscription
-    case "Query": return AppSyncAPI.Objects.Query
     case "ModelTodoConnection": return AppSyncAPI.Objects.ModelTodoConnection
+    case "Mutation": return AppSyncAPI.Objects.Mutation
+    case "Query": return AppSyncAPI.Objects.Query
+    case "Subscription": return AppSyncAPI.Objects.Subscription
+    case "Todo": return AppSyncAPI.Objects.Todo
     default: return nil
     }
   }

--- a/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.pbxproj
+++ b/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.pbxproj
@@ -580,15 +580,15 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/aws-amplify/amplify-swift.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.51.1;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.53.2;
 			};
 		};
 		218CFDFB2C5AD4BB009D70B9 /* XCRemoteSwiftPackageReference "amplify-ui-swift-authenticator" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/aws-amplify/amplify-ui-swift-authenticator";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 1.2.3;
 			};
 		};

--- a/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tests/IntegrationTestApp/IntegrationTestApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/aws-amplify/amplify-swift.git",
       "state" : {
-        "revision" : "cfdda779c9bc699447b84a8afd9c234ace4f5ffd",
-        "version" : "2.51.1"
+        "revision" : "d46019eea8299879a1e24a5d39cc67e1433c198a",
+        "version" : "2.53.3"
       }
     },
     {
@@ -32,8 +32,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apollographql/apollo-ios.git",
       "state" : {
-        "revision" : "104cc94e97741e71f5c8fc9709bf909c464a9702",
-        "version" : "1.14.1"
+        "revision" : "1abd62f6cbc8c1f4405919d7eb6cd8e96967b07c",
+        "version" : "1.25.3"
+      }
+    },
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "4b99975677236d13f0754339864e5360142ff5a1",
+        "version" : "1.30.3"
       }
     },
     {
@@ -41,17 +50,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/awslabs/aws-crt-swift",
       "state" : {
-        "revision" : "5be6550f81c760cceb0a43c30d4149ac55c5640c",
-        "version" : "0.52.1"
+        "revision" : "8241ad06622f7351e8843dfab6bbce14fe6bce5d",
+        "version" : "0.54.2"
       }
     },
     {
       "identity" : "aws-sdk-swift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/awslabs/aws-sdk-swift.git",
+      "location" : "https://github.com/awslabs/aws-sdk-swift",
       "state" : {
-        "revision" : "8b5336764297d34157bd580374b5f6e182746759",
-        "version" : "1.5.18"
+        "revision" : "61d0ab5b429599f22c44b71b0737f030dc82f76b",
+        "version" : "1.6.7"
       }
     },
     {
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/smithy-lang/smithy-swift",
       "state" : {
-        "revision" : "a6cac0739d76ef08e2d927febc682d9898e76fe2",
-        "version" : "0.152.0"
+        "revision" : "0f3fb709fd034ad4b7a19567858571d08a5f4cbe",
+        "version" : "0.175.0"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "309a47b2b1d9b5e991f36961c983ecec72275be3",
-        "version" : "1.6.1"
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
       }
     },
     {
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "f70225981241859eb4aa1a18a75531d26637c8cc",
-        "version" : "1.4.0"
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
       }
     },
     {
@@ -131,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "042e1c4d9d19748c9c228f8d4ebc97bb1e339b0b",
-        "version" : "1.0.4"
+        "revision" : "6c050d5ef8e1aa6342528460db614e9770d7f804",
+        "version" : "1.1.1"
       }
     },
     {
@@ -149,8 +158,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "4b092f15164144c24554e0a75e080a960c5190a6",
-        "version" : "1.14.0"
+        "revision" : "7d5f6124c91a2d06fb63a811695a3400d15a100e",
+        "version" : "1.17.1"
       }
     },
     {
@@ -167,8 +176,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "6f70fa9eab24c1fd982af18c281c4525d05e3095",
+        "version" : "4.2.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "baa932c1336f7894145cbaafcd34ce2dd0b77c97",
+        "version" : "1.3.1"
       }
     },
     {
@@ -176,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "1625f271afb04375bf48737a5572613248d0e7a0",
-        "version" : "1.4.0"
+        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
+        "version" : "1.6.0"
       }
     },
     {
@@ -185,8 +203,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-types.git",
       "state" : {
-        "revision" : "a0a57e949a8903563aba4615869310c0ebf14c03",
-        "version" : "1.4.0"
+        "revision" : "45eb0224913ea070ec4fba17291b9e7ecf4749ca",
+        "version" : "1.5.1"
       }
     },
     {
@@ -194,8 +212,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "ce592ae52f982c847a4efc0dd881cc9eb32d29f2",
-        "version" : "1.6.4"
+        "revision" : "2778fd4e5a12a8aaa30a3ee8285f4ce54c5f3181",
+        "version" : "1.9.1"
       }
     },
     {
@@ -212,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "a18bddb0acf7a40d982b2f128ce73ce4ee31f352",
-        "version" : "2.86.2"
+        "revision" : "233f61bc2cfbb22d0edeb2594da27a20d2ce514e",
+        "version" : "2.93.0"
       }
     },
     {
@@ -221,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "a55c3dd3a81d035af8a20ce5718889c0dcab073d",
-        "version" : "1.29.0"
+        "revision" : "cc599775aa85d04340f09b47e5432564f9889ae7",
+        "version" : "1.32.0"
       }
     },
     {
@@ -230,8 +248,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "5e9e99ec96c53bc2c18ddd10c1e25a3cd97c55e5",
-        "version" : "1.38.0"
+        "revision" : "c2ba4cfbb83f307c66f5a6df6bb43e3c88dfbf80",
+        "version" : "1.39.0"
       }
     },
     {
@@ -239,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "b2b043a8810ab6d51b3ff4df17f057d87ef1ec7c",
-        "version" : "2.34.1"
+        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
+        "version" : "2.36.0"
       }
     },
     {
@@ -248,8 +266,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e645014baea2ec1c2db564410c51a656cf47c923",
-        "version" : "1.25.1"
+        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
+        "version" : "1.26.0"
       }
     },
     {
@@ -266,8 +284,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "2547102afd04fe49f1b286090f13ebce07284980",
-        "version" : "1.31.1"
+        "revision" : "c169a5744230951031770e27e475ff6eefe51f9d",
+        "version" : "1.33.3"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "1983448fefc717a2bc2ebde5490fe99873c5b8a6",
+        "version" : "1.2.1"
       }
     },
     {
@@ -275,8 +302,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "e7187309187695115033536e8fc9b2eb87fd956d",
-        "version" : "2.8.0"
+        "revision" : "1de37290c0ab3c5a96028e0f02911b672fd42348",
+        "version" : "2.9.1"
       }
     },
     {
@@ -284,8 +311,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "395a77f0aa927f0ff73941d7ac35f2b46d47c9db",
-        "version" : "1.6.3"
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
       }
     },
     {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/aws-appsync-apollo-extensions-swift/security/dependabot/1

*Description of changes:*
PR to update Amplify dependency to fix dependabot alert
 - Changes are in the integration test app
 - regenerated AppSyncAPI files for newer Apollo version
 - updated runner and simulator versions to run on macos-15 runner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
